### PR TITLE
frequency from msa count include all residues

### DIFF
--- a/pycanal/pycanal.py
+++ b/pycanal/pycanal.py
@@ -176,8 +176,12 @@ class Canal():
         
         # Calculate MSA frequencies
         all_sites = fasta_df.values.reshape(-1)
-        msa_counts = np.unique(all_sites, return_counts=True)
-        msa_counts = pd.Series(msa_counts[1], index=msa_counts[0])
+        msa_counts_fasta = np.unique(all_sites, return_counts=True)
+        all_amino_acids = {aa: 0 for aa in self.aminoacid_letters}
+        observed_counts = dict(zip(msa_counts_fasta[0], msa_counts_fasta[1]))
+        all_amino_acids.update(observed_counts)
+        msa_counts = pd.Series(all_amino_acids)
+
         msa_freqs = pd.DataFrame(index=self.aminoacid_letters, dtype=float)
         msa_freqs['msa_freqs'] = msa_counts[np.array(self.aminoacid_letters)]
         msa_freqs['msa_freqs'] = msa_freqs['msa_freqs'] / msa_freqs['msa_freqs'].sum()


### PR DESCRIPTION
When a MSA do not include a specific residue for instance the following msa:


```
> pdb|3PHL|A
MGSSHHHHHHSSGLVPRGSHMASMTGGQQMGRGSEFMKITISGTGYVGLSNGVLIAQNHEVVALDIVQAKVDMLNQKISPIVDKEIQEYLAEKPLNFRATTDKHDAYRNADYVIIATPTDYDPKTNYFNTSTVEAVIRDVTEINPNAVMIIKSTIPVGFTRDIKERLGIDNVIFSPEFLREGRALYDNLHPSRIVIGERSARAERFADLLKEGAIKQDIPTLFTDSTEAEAIKLFANTYLALRVAYFNELDSYAESQGLNSKQIIEGVCLDPRIGNHYNNPSFGYGGYCLPKDTKQLLANYESVPNNIIAAIVDANRTRKDFIADSILARKPKVVGVYRLIMKSGSDNFRASSIQGIMKRIKAKGIPVIIYEPVMQEDEFFNSRVVRDLNAFKQEADVIISNRMAEELADVADKVYTRDLFGND
> pdb|3PID|A
MGSSHHHHHHSSGLVPRGSHMASMTGGQQMGRGSEFMKITISGTGYVGLSNGVLIAQNHEVVALDIVQAKVDMLNQKISPIVDKEIQEYLAEKPLNFRATTDKHDAYRNADYVIIATPTDYDPKTNYFNTSTVEAVIRDVTEINPNAVMIIKSTIPVGFTRDIKERLGIDNVIFSPEFLREGRALYDNLHPSRIVIGERSARAERFADLLKEGAIKQDIPTLFTDSTEAEAIKLFANTYLALRVAYFNELDSYAESQGLNSKQIIEGVCLDPRIGNHYNNPSFGYGGYCLPKDTKQLLANYESVPNNIIAAIVDANRTRKDFIADSILARKPKVVGVYRLIMKSGSDNFRASSIQGIMKRIKAKGIPVIIYEPVMQEDEFFNSRVVRDLNAFKQEADVIISNRMAEELADVADKVYTRDLFGND
> ref|WP_004175261.1|
------------------------------------MKITISGTGYVGLSNGVLIAQNHEVVALDIVQAKVDMLNQKISPIVDKEIQEYLAEKPLNFRATTDKHDAYRNADYVIIATPTDYDPKTNYFNTSTVEAVIRDVTEINPNAVMIIKSTIPVGFTRDIKERLGIDNVIFSPEFLREGRALYDNLHPSRIVIGERSARAERFADLLKEGAIKQDIPTLFTDSTEAEAIKLFANTYLALRVAYFNELDSYAESQGLNSKQIIEGVCLDPRIGNHYNNPSFGYGGYCLPKDTKQLLANYESVPNNIIAAIVDANRTRKDFIADSILARKPKVVGVYRLIMKSGSDNFRASSIQGIMKRIKAKGIPVIIYEPVMQEDEFFNSRVVRDLNAFKQEADVIISNRMAEELADVADKVYTRDLFGND
> tpg|HBT4763487.1|
------------------------------------MKITISGTGYVGLSNGVLIAQNHEVVALDIVQAKVDMLNQKVSPIVDKEIQEYLAEKPLNFRATTDKHDAYRNADYVIIATPTDYDPKTNYFNTSTVEAVIRDVTEINPNAVMIIKSTIPVGFTRDIKERLGIDNVIFSPEFLREGRALYDNLHPSRIVIGERSARAERFADLLKEGAIKQDIPTLFTDSTEAEAIKLFANTYLALRVAYFNELDSYAESQGLNSKQIIEGVCLDPRIGNHYNNPSFGYGGYCLPKDTKQLLANYESVPNNIIAAIVDANRTRKDFIADSILARKPKVVGVYRLIMKSGSDNFRASSIQGIMKRIKAKGIPVIIYEPVMQEDEFFNSRVVRDLNAFKQEADVIISNRMAEELADVADKVYTRDLFGND
> ref|WP_105441463.1|
------------------------------------MKITISGTGYVGLSNGVLIAQNHEVVALDIVQAKVDMLNQKISPIVDKEIQEYLAEKPLNFRATTDKHDAYRNADYVIIATPTDYDPKTNYFNTSTVEAVIRDVTEINPNAVMIIKSTIPVGFTRDIKERLGIDNVIFSPEFLREGRALYDNLHPSRIVIGERSARAERFADLLKEGAIKQDIPTLFTDSTEAEAIKLFANTYLALRVAYFNELDSYAESQGLNSKQIIEGVCLDPRIGNHYNNPSFGYGGYCLPKDTKQLLANYESVPNNIIAAIVDANRTRKDFIADSILARKPKVVGVYRLIMKSGSDNFRATSIQGIMKRIKAKGIPVIIYEPVMQEDEFFNSRVVRDLNAFKQEADVIISNRMAEELADVADKVYTRDLFGND
> ref|WP_032429644.1|
```

That not  include any tryptophan, the code fail trying to indexing W under the frequency calculation. This ensures that the input aminoacids are counted as 0. 

